### PR TITLE
Updated 'htags-server' parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.deb
 *.swo
 *.swp
-__ktags
 ktags-build

--- a/README.md
+++ b/README.md
@@ -1,22 +1,26 @@
 # Ktags: Source code tagging and navigation tool
 
-Ktags makes it easy to use traditional source code tagging systems such as Cscope, Ctags, GNU Global's Gtags, Gscope and Htags.
-Ktags use GNU Global's `htags-server` for HTML source code navugation.
+Ktags makes it easy to use traditional source code tagging systems such as Cscope, Ctags, GNU Global's Gscope Gtags and Htags.
+
+With `--browse` option allows you to explore C/C++ code in web-browser with syntax higlighting and cross references.<br>
+GNU Global's `htags-server` web-server helps to explore the code in web-browser at <http://localhost:8888>.
+
+## Requirements:
+`cscope`, `ctags` and `global`.
 
 ## Usage: 
 ### `ktags [options]...`
 
-## Command line options:
+**Command line options:**
 ```
-    -a  --all      -- Generate Ctags and Gtags
-    -b  --browse   -- Start webserver and open browser to explore source code
-    -c  --ctags    -- Generate only the Ctags
-    -g  --gtags    -- Generate only the Gtags
-    -D  --deploy   -- Deploy Ktags files into local webserver
-    -d  --delete   -- Delete Ktags database files
-    -V  --verbose  -- Enable verbose mode
-    -v  --version  -- Print Ktags version
+    -a  --all      -- Generate both Ctags and Gtags symbols
+    -b  --browse   -- Instantly explore the source code in web-browser at http://localhost:8888
+    -c  --ctags    -- Generate tags with Ctags tool
+    -g  --gtags    -- Generate tags eith Gtags tool
+    -d  --delete   -- Delete tags database files in current path
+    -V  --verbose  -- Enable debug mode
+    -v  --version  -- Print package version
     -h  --help     -- Show this help menu
-                   -- Running Ktags without arguments will generate
+                   -- Running application without arguments will generate
                       Ctags and Cscope databases
 ```


### PR DESCRIPTION
- Removed hard coded localhost URL
- Removed `deploy` option for now
- Retry option is enabled in `htags-server`
- Updated README and help menu
- Removed Cflow package name in dependency list
